### PR TITLE
Feature/be/4/kakao logout ProfileMember에서도 짧은소개를 리턴하도록 수정

### DIFF
--- a/src/main/java/com/haribo/auth_service/auth/application/service/AuthService.java
+++ b/src/main/java/com/haribo/auth_service/auth/application/service/AuthService.java
@@ -5,4 +5,5 @@ import com.haribo.auth_service.auth.presentation.response.KakaoMemberResponse;
 public interface AuthService {
     String getKakaoLoginUrl();
     KakaoMemberResponse getKakaoInfoWithCode(String code) throws Exception;
+    String getKakaoLogoutUrl();
 }

--- a/src/main/java/com/haribo/auth_service/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/haribo/auth_service/auth/application/service/AuthServiceImpl.java
@@ -96,6 +96,13 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
+    @Override
+    public String getKakaoLogoutUrl() {
+        return KAKAO_AUTH_URI + "/oauth/logout"
+                + "?client_id=" + KAKAO_CLIENT_ID
+                + "&logout_redirect_uri=" + KAKAO_REDIRECT_LOGOUT;
+    }
+
     private String getKakaoAccessToken(String code) throws ParseException {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded");

--- a/src/main/java/com/haribo/auth_service/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/haribo/auth_service/auth/application/service/AuthServiceImpl.java
@@ -147,7 +147,7 @@ public class AuthServiceImpl implements AuthService {
         return (JSONObject) jsonParser.parse(response.getBody());
     }
 
-    private KakaoMemberDto registerAndLoginIfNeeded(JSONObject jsonObj) throws Exception {
+    private KakaoMemberDto registerAndLoginIfNeeded(JSONObject jsonObj){
         JSONObject account = (JSONObject) jsonObj.get("kakao_account");
         JSONObject profile = (JSONObject) account.get("profile");
 

--- a/src/main/java/com/haribo/auth_service/auth/presentation/AuthController.java
+++ b/src/main/java/com/haribo/auth_service/auth/presentation/AuthController.java
@@ -1,12 +1,15 @@
 package com.haribo.auth_service.auth.presentation;
 
+import com.haribo.auth_service.auth.application.dto.kakaoapi.KakaoMemberDto;
 import com.haribo.auth_service.auth.application.service.AuthService;
 import com.haribo.auth_service.auth.presentation.response.KakaoMemberResponse;
+import com.haribo.auth_service.member.domain.ProfileMember;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
@@ -50,11 +53,31 @@ public class AuthController {
         return new RedirectView(kakaoLogoutUrl);
     }
 
-    @GetMapping("/redirect-kakalogout")
+    @GetMapping("/redirect-kakaologout")
     public RedirectView kakalogout() {
         logger.info("kakao-logout 후에 진행할 로직");
         // TODO : 배포 후 사이트 주소 넣을 예정
-        return new RedirectView();
+        return new RedirectView("http://localhost:8080/");
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<KakaoMemberDto> getUserProfile(HttpServletRequest request) {
+        logger.info("로그인한 멤버의 정보를 가져오는 API 호출");
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        ProfileMember profileMember = (ProfileMember) session.getAttribute("profileMember");
+        if(profileMember == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        KakaoMemberDto kakaoMemberDto = KakaoMemberDto.builder()
+                .profileMember(profileMember)
+                .build();
+
+        return ResponseEntity.ok().body(kakaoMemberDto);
     }
 
 }

--- a/src/main/java/com/haribo/auth_service/auth/presentation/AuthController.java
+++ b/src/main/java/com/haribo/auth_service/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.haribo.auth_service.auth.presentation;
 import com.haribo.auth_service.auth.application.service.AuthService;
 import com.haribo.auth_service.auth.presentation.response.KakaoMemberResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,4 +33,28 @@ public class AuthController {
         KakaoMemberResponse kakaoMemberResponse = authService.getKakaoInfoWithCode(request.getParameter("code"));
         return ResponseEntity.ok().body(kakaoMemberResponse);
     }
+
+    @GetMapping("/logout")
+    public RedirectView logout(HttpServletRequest request) {
+        logger.info("kakao-logout 화면 진입");
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+            logger.info("세션 무효화 성공");
+        } else {
+            logger.info("세션이 존재하지 않아요");
+        }
+
+        String kakaoLogoutUrl = authService.getKakaoLogoutUrl();
+        return new RedirectView(kakaoLogoutUrl);
+    }
+
+    @GetMapping("/redirect-kakalogout")
+    public RedirectView kakalogout() {
+        logger.info("kakao-logout 후에 진행할 로직");
+        // TODO : 배포 후 사이트 주소 넣을 예정
+        return new RedirectView();
+    }
+
 }

--- a/src/main/java/com/haribo/auth_service/auth/presentation/AuthController.java
+++ b/src/main/java/com/haribo/auth_service/auth/presentation/AuthController.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,9 @@ import org.springframework.web.servlet.view.RedirectView;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Value("${base.server-domain}")
+    private String serverDomain;
 
     private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
 
@@ -56,8 +60,8 @@ public class AuthController {
     @GetMapping("/redirect-kakaologout")
     public RedirectView kakalogout() {
         logger.info("kakao-logout 후에 진행할 로직");
-        // TODO : 배포 후 사이트 주소 넣을 예정
-        return new RedirectView("http://localhost:8080/");
+        return new RedirectView("http://"+serverDomain+ ":8080/");
+//        return new RedirectView("http://localhost:8080/");
     }
 
     @GetMapping("/profile")

--- a/src/main/java/com/haribo/auth_service/member/domain/ProfileMember.java
+++ b/src/main/java/com/haribo/auth_service/member/domain/ProfileMember.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "profile")
+@Table(name = "profile_member")
 public class ProfileMember extends BaseTimeEntity {
     @Id
     @Column(name = "profile_id")
@@ -38,4 +38,7 @@ public class ProfileMember extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "member_status", nullable = false)
     private MemberStatus memberStatus;
+
+    @Column(name = "simple_introduce", nullable = false)
+    private String simpleIntroduce;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,4 @@ kakao:
 
 base:
   profile-image: ${BASE_PROFILE_IMAGE}
+  server-domain : ${SERVER_DOMAIN}


### PR DESCRIPTION
## 🗂️ 이슈 연결
- #4 

</br>

## 📌 수정한 API
- 기능 : `Get  /api/v1/auth/profile`
- 응답 
``` json
{
  "profileMember": {
    "createdDate": "2024-08-12T14:51:23.1373641",
    "modifiedDate": "2024-08-12T14:51:23.1373641",
    "profileId": "0a9f30d7-cccc-4312-9e50-f8630ad1011f",
    "name": "박소미",
    "nickName": "박소미",
    "email": "terst@gmail.com",
    "profileImage": "https://item.kakaocdn.net/do/1e4c069c7d7c8a795d04560bc29122d6339e41ce89b663315d96faecd7cfd11b",
    "memberStatus": "ACTIVE",
    "simpleIntroduce": ""
  }
}
```

</br>
